### PR TITLE
Fix dict index in embedding retrieval

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -228,7 +228,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         if self.peft_config[adapter_name].peft_type == PeftType.PREFIX_TUNING:
             prompt_tokens = prompt_tokens[:, : self.peft_config[adapter_name].num_virtual_tokens]
 
-        if self.peft_config.peft_type == PeftType.MULTITASK_PROMPT_TUNING:
+        if self.peft_config[adapter_name].peft_type == PeftType.MULTITASK_PROMPT_TUNING:
             prompt_embeddings = super(MultitaskPromptEmbedding, self.prompt_encoder[adapter_name]).forward(
                 prompt_tokens
             )


### PR DESCRIPTION
Fixes a small issue in the helper for exporting the prompt embedding - previously `.peft_config` was the actual peft config subclass, but now it's a dict mapping to that subclass with an adapter `str` key. 